### PR TITLE
implement an example of lazy-loading (#3)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["syntax-dynamic-import"]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 6,
     "sourceType": "module"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ a feather) organization.
 * _src_ - application code
 * _src/components/_ - resusable UI features, typically directives.  A `BootstrapComponent` has been designated to manage starting up the application, from _index.js_
 * _src/services/_ -  APIs for handling backend REST APIs or browser APIs, non UI related "helpers"
-* _src/views/_ -  routable states ("pages"), generally exposed with `class` controllers
+* _src/views/_ -  routable states ("pages"), generally exposed with `class` controllers. Some are configured to [lazy load](https://github.com/kenzanmedia/angularjs-webpack-seed/wiki#lazy-loading).
 * _src/index.html_ - main layout of the application
 * _src/index.js_ - main entry way into the application and pulls in the application's `BootstrapComponent`
 * _src/routes.js_ - routes for the application, maps to different views

--- a/package.json
+++ b/package.json
@@ -34,12 +34,15 @@
     "angular-material": "^1.1.3",
     "angular-ui-router": "^0.4.2",
     "http-server": "^0.9.0",
-    "jquery": "^3.2.1"
+    "jquery": "^3.2.1",
+    "oclazyload": "^1.1.0"
   },
   "devDependencies": {
     "angular-mocks": "^1.6.4",
     "babel-core": "^6.24.0",
+    "babel-eslint": "^7.2.3",
     "babel-loader": "^6.4.1",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-es2015": "^6.24.0",
     "chai": "^3.5.0",
     "css-loader": "^0.27.3",
@@ -70,7 +73,7 @@
     "sinon": "^2.2.0",
     "sinon-chai": "^2.10.0",
     "style-loader": "^0.16.1",
-    "webpack": "^2.3.2",
+    "webpack": "^2.5.1",
     "webpack-dev-server": "^2.4.2",
     "webpack-md5-hash": "^0.0.5",
     "webpack-merge": "^4.1.0"

--- a/src/views/home/home.controller.module.js
+++ b/src/views/home/home.controller.module.js
@@ -1,0 +1,5 @@
+import HomeController from './home.controller';
+
+export default angular
+  .module('tgh.view.home.ctrl', [])
+  .controller('HomeController', HomeController);

--- a/src/views/users/users.config.js
+++ b/src/views/users/users.config.js
@@ -1,16 +1,20 @@
-import UsersController from './users.controller';
-import UsersTemplate from './users.template.html';
-
 export default function UsersConfig($stateProvider) {
   'ngInject';
 
   $stateProvider.state({
     name: 'users',
     url: '/users',
-    template: UsersTemplate,
-    controller: UsersController,
+    templateProvider: () => import(/* webpackChunkName: "users.route" */ './users.template.html'),
+    controller: 'UsersController',
     controllerAs: 'vm',
     resolve: {
+      loadController: ['$ocLazyLoad', function ($ocLazyLoad) {
+        return import(/* webpackChunkName: "users.route" */ './users.controller.module')
+          .then((module) => {
+            $ocLazyLoad.inject('tgh.view.users.ctrl');
+            return module;
+          });
+      }],
       primaryUser: ['UsersService', function (UsersService) {
         return UsersService.getPrimaryUser();
       }]

--- a/src/views/users/users.controller.module.js
+++ b/src/views/users/users.controller.module.js
@@ -1,0 +1,5 @@
+import UsersController from './users.controller';
+
+export default angular
+  .module('tgh.view.users.ctrl', [])
+  .controller('UsersController', UsersController);

--- a/src/views/users/users.module.js
+++ b/src/views/users/users.module.js
@@ -1,9 +1,11 @@
 import UsersConfig from './users.config';
 
 import uirouter from 'angular-ui-router';
+import oclazyload from 'oclazyload';
 
 export default angular
   .module('tgh.view.users', [
-    uirouter
+    uirouter,
+    oclazyload
   ])
   .config(UsersConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,7 +25,7 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
-acorn@4.0.4:
+acorn@4.0.4, acorn@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
@@ -33,9 +33,9 @@ acorn@^3.0.0, acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.3, acorn@^4.0.4:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
+acorn@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
 acorn@~2.6.4:
   version "2.6.4"
@@ -307,6 +307,15 @@ babel-core@^6.24.0:
     slash "^1.0.0"
     source-map "^0.5.0"
 
+babel-eslint@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-traverse "^6.23.1"
+    babel-types "^6.23.0"
+    babylon "^6.17.0"
+
 babel-generator@^6.24.0:
   version "6.24.0"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.0.tgz#eba270a8cc4ce6e09a61be43465d7c62c1f87c56"
@@ -415,6 +424,10 @@ babel-plugin-check-es2015-constants@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -678,9 +691,9 @@ babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.15.0:
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
+babylon@^6.11.0, babylon@^6.15.0, babylon@^6.17.0:
+  version "6.17.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.0.tgz#37da948878488b9c4e3c4038893fa3314b3fc932"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -3137,7 +3150,7 @@ json3@3.3.2, json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
@@ -3941,6 +3954,10 @@ object.omit@^2.0.0:
 obuf@^1.0.0, obuf@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.1.tgz#104124b6c602c6796881a042541d36db43a5264e"
+
+oclazyload@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/oclazyload/-/oclazyload-1.1.0.tgz#a9807322f190820a81c022f2ef1701d036d83e87"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -5398,7 +5415,7 @@ style-loader@^0.16.1:
   dependencies:
     loader-utils "^1.0.2"
 
-supports-color@3.1.2, supports-color@^3.1.0, supports-color@^3.1.1:
+supports-color@3.1.2, supports-color@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -5408,7 +5425,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.2.3:
+supports-color@^3.1.0, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -5893,11 +5910,11 @@ webpack@^1.13.0:
     watchpack "^0.2.1"
     webpack-core "~0.6.9"
 
-webpack@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.3.2.tgz#7d521e6f0777a3a58985c69425263fdfe977b458"
+webpack@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-2.5.1.tgz#61742f0cf8af555b87460a9cd8bba2f1e3ee2fce"
   dependencies:
-    acorn "^4.0.4"
+    acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"
     ajv "^4.7.0"
     ajv-keywords "^1.1.1"
@@ -5905,6 +5922,7 @@ webpack@^2.3.2:
     enhanced-resolve "^3.0.0"
     interpret "^1.0.0"
     json-loader "^0.5.4"
+    json5 "^0.5.1"
     loader-runner "^2.3.0"
     loader-utils "^0.2.16"
     memory-fs "~0.4.1"


### PR DESCRIPTION
Resolves (#3).

As implemented, the lazy-loading employed here leverages webpack 2's support
for the pending dynamic import syntax. Eslint and babel now include plugins and
configurations that accept the new syntax.

Here's how it works: The dynamic import requests the files needed for the
application's routes. It provides the promise returned by the templateProvider
function for each route. For the controller, the approach is more indirect. At
the time of configuration, the route knows its controller by name, but that is
all. Within a resolve function, the ocLazyLoad service injects the module that
registers the controller. Now, when the router looks up the controller by name
it finds it in the registry.

Note: Grouping the related imports in a common chunk requires the use of a
"magic comment", which in turn required a webpack upgrade.