### PR TITLE
README mentions Vagrant but repo lacks Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Recommended plugins to have are:
 $ npm install -g yarn@0.21.3
 ```
 
-3) Now install the build and application dependencies by running `$ yarn install` (Vagrant will do this for you)
+3) Now install the build and application dependencies by running `$ yarn install`
 
 ## Project Layout
 An overview of important files and configurations for the applications


### PR DESCRIPTION
The README.md at line 50 said "(Vagrant will do this for you)", referencing `yarn install`, but the repository has no Vagrantfile. Assuming it will not have Vagrantfile, I recommend removing this note to avoid confusion.